### PR TITLE
Tests/fixing for v0.4.2

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -32,7 +32,7 @@ jobs:
           pip install -e .
 
       - name: Run tests
-        run: python run_tests.py --regression --feature
+        run: python run_tests.py --regression --feature --skip requires_api_key
 
   release:
     needs: test

--- a/tests/regression_test_versioning.py
+++ b/tests/regression_test_versioning.py
@@ -8,7 +8,7 @@ import sys
 import os
 import unittest
 import json
-import toml
+import tomli
 from pathlib import Path
 
 # Import test decorators
@@ -97,7 +97,7 @@ class TestSemanticReleaseConfiguration(unittest.TestCase):
                        "pyproject.toml should exist")
         
         with open(self.pyproject_path, 'r') as f:
-            config = toml.load(f)
+            config = tomli.load(f)
         
         self.assertIn("project", config, 
                      "project section should exist in pyproject.toml")
@@ -154,7 +154,7 @@ class TestSemanticReleaseConfiguration(unittest.TestCase):
     def test_version_format_is_semantic(self):
         """Test that the current version follows semantic versioning format."""
         with open(self.pyproject_path, 'r') as f:
-            config = toml.load(f)
+            config = tomli.load(f)
         
         version = config["project"]["version"]
 


### PR DESCRIPTION
This pull request introduces minor updates to the test workflow and regression tests to improve compatibility and reliability. The main changes include updating the test command to skip tests requiring an API key and replacing the `toml` library with `tomli` for parsing TOML files in regression tests.

**Test workflow improvements:**

* Updated the test command in `.github/workflows/semantic-release.yml` to skip tests that require an API key by adding the `--skip requires_api_key` flag.

**Regression test compatibility:**

* Replaced the `toml` library with `tomli` for reading TOML files in `tests/regression_test_versioning.py`, including the import statement and usage in the `test_pyproject_toml_has_version` test. [[1]](diffhunk://#diff-467c6e85e10c678b9e42eeb6b5632271b3af1f027ac2f405e4fd9a7df58388c5L11-R11) [[2]](diffhunk://#diff-467c6e85e10c678b9e42eeb6b5632271b3af1f027ac2f405e4fd9a7df58388c5L100-R100)